### PR TITLE
Update endpoint URLs in AutodeskAuthenticationDefaults.cs to v2

### DIFF
--- a/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationDefaults.cs
+++ b/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationDefaults.cs
@@ -34,15 +34,15 @@ public static class AutodeskAuthenticationDefaults
     /// <summary>
     /// Default value for <see cref="OAuthOptions.AuthorizationEndpoint"/>.
     /// </summary>
-    public static readonly string AuthorizationEndpoint = "https://developer.api.autodesk.com/authentication/v1/authorize";
+    public static readonly string AuthorizationEndpoint = "https://developer.api.autodesk.com/authentication/v2/authorize";
 
     /// <summary>
     /// Default value for <see cref="OAuthOptions.TokenEndpoint"/>.
     /// </summary>
-    public static readonly string TokenEndpoint = "https://developer.api.autodesk.com/authentication/v1/gettoken";
+    public static readonly string TokenEndpoint = "https://developer.api.autodesk.com/authentication/v2/gettoken";
 
     /// <summary>
     /// Default value for <see cref="OAuthOptions.UserInformationEndpoint"/>.
     /// </summary>
-    public static readonly string UserInformationEndpoint = "https://developer.api.autodesk.com/userprofile/v1/users/@me";
+    public static readonly string UserInformationEndpoint = "https://api.userprofile.autodesk.com/userinfo";
 }


### PR DESCRIPTION
Autodesk is deprecating v1 auth APIs, per https://aps.autodesk.com/blog/authentication-v2-and-deprecation-v1

New endpoints are set based on the following documentation links:  https://aps.autodesk.com/en/docs/oauth/v2/reference/http/authorize-GET/ https://aps.autodesk.com/en/docs/oauth/v2/reference/http/gettoken-POST/ https://aps.autodesk.com/en/docs/oauth/v2/reference/http/userinfo-GET/